### PR TITLE
CIP-30 Change license installation strategy

### DIFF
--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -107,8 +107,25 @@ provisioner "file" {
   }
 }
 
+provisioner "file" {
+  destination = "/tmp/nomad_license.hclic"
+  content     = var.license
+
+  connection {
+    type                = "ssh"
+    user                = var.ssh_user
+    private_key         = var.ssh_private_key
+    timeout             = var.ssh_timeout
+    host                = var.cluster_nodes_public_ips != null ? var.cluster_nodes_public_ips[each.key] : each.value
+    bastion_host        = var.ssh_bastion_host
+    bastion_port        = var.ssh_bastion_port
+    bastion_private_key = var.ssh_bastion_private_key
+    bastion_user        = var.ssh_bastion_user
+  }
+}
+
 provisioner "remote-exec" {
-  inline = ["sudo mv /tmp/nomad.hcl.tmpl /etc/nomad.d/nomad.hcl.tmpl && sudo mv /tmp/nomad_ca.tmpl /etc/nomad.d/nomad_ca.tmpl && sudo mv /tmp/nomad_cert.tmpl /etc/nomad.d/nomad_cert.tmpl && sudo mv /tmp/nomad_keyfile.tmpl /etc/nomad.d/nomad_keyfile.tmpl && sudo mv /tmp/nomad-server.hcl /etc/nomad.d/nomad-server.hcl"]
+  inline = ["sudo mv /tmp/nomad.hcl.tmpl /etc/nomad.d/nomad.hcl.tmpl && sudo mv /tmp/nomad_ca.tmpl /etc/nomad.d/nomad_ca.tmpl && sudo mv /tmp/nomad_cert.tmpl /etc/nomad.d/nomad_cert.tmpl && sudo mv /tmp/nomad_keyfile.tmpl /etc/nomad.d/nomad_keyfile.tmpl && sudo mv /tmp/nomad-server.hcl /etc/nomad.d/nomad-server.hcl && sudo mv /tmp/nomad_license.hclic /etc/nomad.d/license.hclic"]
   connection {
     type                = "ssh"
     user                = var.ssh_user
@@ -190,7 +207,7 @@ resource "null_resource" "nomad_acl_bootstrap" {
   }
 
   provisioner "remote-exec" {
-    inline = ["chmod +x /tmp/nomad_acl_bootstrap.sh && export LICENSE=${var.license} && sh /tmp/nomad_acl_bootstrap.sh"]
+    inline = ["chmod +x /tmp/nomad_acl_bootstrap.sh && sh /tmp/nomad_acl_bootstrap.sh"]
     connection {
       type                = "ssh"
       user                = var.ssh_user

--- a/modules/nomad-cluster/nomad-server.hcl
+++ b/modules/nomad-cluster/nomad-server.hcl
@@ -4,6 +4,7 @@ log_level = "DEBUG"
 server {
   enabled = true
   bootstrap_expect = 3
+  license_path = "/etc/nomad.d/license.hclic"
 }
 
 server_join {

--- a/modules/nomad-cluster/nomad-server.hcl.tmpl
+++ b/modules/nomad-cluster/nomad-server.hcl.tmpl
@@ -4,6 +4,7 @@ log_level = "DEBUG"
 server {
   enabled = true
   bootstrap_expect = 3
+  license_path = "/etc/nomad.d/license.hclic"
 }
 
 server_join {

--- a/modules/nomad-cluster/scripts/nomad_acl_bootstrap.sh
+++ b/modules/nomad-cluster/scripts/nomad_acl_bootstrap.sh
@@ -19,10 +19,4 @@ export NOMAD_TOKEN="`sudo cat /root/nomad_tokens | awk '/Secret/{print $4}'`" &&
   vault write nomad/role/anon-restricted policies=nomad-anon-restricted
 }
 
-if [[ -n $LICENSE ]]
-then
-  echo "Adding Nomad License"
-  echo "$LICENSE" | nomad license put -token="$(sudo cat /root/nomad_tokens | awk '/Secret/{print $4}')" -
-fi
-
 sudo rm -f /root/nomad_tokens nomad-anon.hcl


### PR DESCRIPTION
TODO:
- [x] OSS: check if license_path in server does not cause any problem
- [x] ENT: check if it is working

Compatible with Nomad >= 1.1.0
Uncompatible with Nomad < 1.1.0

@efbar do we want to support old Nomad versions or drop them? If we want to support both installation strategy, we might need to add a variable nomad version, and reason against its value?

Closes #14 